### PR TITLE
Update container config so it always starts up.

### DIFF
--- a/salt-state/init.sls
+++ b/salt-state/init.sls
@@ -41,6 +41,7 @@ so-idh-run:
     - name: so-idh
     - detach: True
     - network_mode: host
+    - restart_policy: always
     - binds:
       - /nsm/idh:/var/tmp:rw
       - /opt/so/conf/idh/opencanary.conf:/etc/opencanaryd/opencanary.conf:ro


### PR DESCRIPTION
This should resolve the issue with so-idh not running when the sensor is rebooted.